### PR TITLE
Add Next.js frontend starter for SaaS Blog API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ media/
 .pytest_cache
 .vscode
 test.html
+frontend/node_modules
+frontend/.next
+frontend/.env.local

--- a/README.md
+++ b/README.md
@@ -88,6 +88,21 @@ fastapi dev app/main.py
 uvicorn app.main:app --reload
 ```
 
+### 5. Run the Next.js frontend (optional)
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Configure `frontend/.env.local`:
+
+```env
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+```
+
+
 ---
 
 ## 📚 API Documentation  

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,21 @@
+# Next.js Frontend
+
+This folder contains a starter Next.js frontend for the SaaS Blog API.
+
+## Run locally
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The app will run on `http://localhost:3000` and expects backend API on `http://localhost:8000`.
+
+## Environment variables
+
+Create `frontend/.env.local`:
+
+```env
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+```

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'http',
+        hostname: 'localhost'
+      }
+    ]
+  }
+};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "saas-blog-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.10",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.5",
+    "typescript": "5.5.3"
+  }
+}

--- a/frontend/src/app/blogs/[id]/page.tsx
+++ b/frontend/src/app/blogs/[id]/page.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+import { fetchBlogById } from '@/lib/api';
+
+export default async function BlogDetailsPage({ params }: { params: { id: string } }) {
+  try {
+    const blog = await fetchBlogById(params.id);
+
+    return (
+      <article className="detail">
+        <Link href="/">← Back to blogs</Link>
+        <h1>{blog.title}</h1>
+        <p className="meta">
+          {blog.author?.username ?? 'Anonymous'} · {new Date(blog.created_at).toLocaleDateString()}
+        </p>
+        <div className="content">{blog.content}</div>
+      </article>
+    );
+  } catch {
+    notFound();
+  }
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,0 +1,126 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #f5f7fb;
+  color: #1a1f36;
+}
+
+header {
+  border-bottom: 1px solid #e6e8ef;
+  background: #fff;
+}
+
+nav {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+nav a {
+  text-decoration: none;
+  color: #1a1f36;
+  font-weight: 600;
+}
+
+main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid #e6e8ef;
+  border-radius: 0.75rem;
+  padding: 1rem;
+}
+
+.card h2 {
+  margin: 0.5rem 0;
+  font-size: 1.1rem;
+}
+
+.card h2 a {
+  color: inherit;
+}
+
+.meta {
+  color: #5f6985;
+  font-size: 0.85rem;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0.5rem 0;
+  padding: 0;
+}
+
+.tags li {
+  background: #eef2ff;
+  color: #3a49a4;
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.75rem;
+}
+
+.stats {
+  display: flex;
+  gap: 0.75rem;
+  color: #5f6985;
+  font-size: 0.85rem;
+}
+
+.heading-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.form {
+  display: grid;
+  gap: 1rem;
+  max-width: 380px;
+}
+
+.form input {
+  width: 100%;
+  margin-top: 0.35rem;
+  border: 1px solid #d4daeb;
+  border-radius: 0.5rem;
+  padding: 0.6rem;
+}
+
+.form button {
+  background: #3a49a4;
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.65rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.detail .content {
+  margin-top: 1rem;
+  white-space: pre-wrap;
+  line-height: 1.65;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'SaaS Blog Frontend',
+  description: 'Next.js frontend for the SaaS Blog API'
+};
+
+export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang="en">
+      <body>
+        <header>
+          <nav>
+            <Link href="/">Home</Link>
+            <Link href="/login">Login</Link>
+          </nav>
+        </header>
+        <main>{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,11 @@
+import { LoginForm } from '@/components/login-form';
+
+export default function LoginPage() {
+  return (
+    <section>
+      <h1>Sign in</h1>
+      <p>Use your API account credentials to store JWT tokens locally for testing authenticated endpoints.</p>
+      <LoginForm />
+    </section>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,0 +1,29 @@
+import { BlogCard } from '@/components/blog-card';
+import { fetchBlogs } from '@/lib/api';
+
+export default async function HomePage({
+  searchParams
+}: {
+  searchParams?: { search?: string };
+}) {
+  const search = searchParams?.search;
+  const blogs = await fetchBlogs({ search, limit: 12, offset: 0 });
+
+  return (
+    <section>
+      <div className="heading-row">
+        <h1>Latest posts</h1>
+        <p>{blogs.total} total posts</p>
+      </div>
+      {blogs.data.length ? (
+        <div className="grid">
+          {blogs.data.map((blog) => (
+            <BlogCard key={blog.id} blog={blog} />
+          ))}
+        </div>
+      ) : (
+        <p>No blogs found.</p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/blog-card.tsx
+++ b/frontend/src/components/blog-card.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+
+import { Blog } from '@/lib/types';
+
+interface BlogCardProps {
+  blog: Blog;
+}
+
+export function BlogCard({ blog }: BlogCardProps) {
+  return (
+    <article className="card">
+      <p className="meta">
+        {blog.author?.username ?? 'Anonymous'} · {new Date(blog.created_at).toLocaleDateString()}
+      </p>
+      <h2>
+        <Link href={`/blogs/${blog.id}`}>{blog.title}</Link>
+      </h2>
+      {blog.tags?.length ? (
+        <ul className="tags">
+          {blog.tags.map((tag) => (
+            <li key={tag}>{tag}</li>
+          ))}
+        </ul>
+      ) : null}
+      <div className="stats">
+        <span>❤️ {blog.likes_count ?? 0}</span>
+        <span>💬 {blog.comments_count ?? 0}</span>
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/components/login-form.tsx
+++ b/frontend/src/components/login-form.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+
+import { login } from '@/lib/api';
+
+export function LoginForm() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsLoading(true);
+    setMessage(null);
+
+    try {
+      const data = await login(username, password);
+      localStorage.setItem('access_token', data.access_token);
+      localStorage.setItem('refresh_token', data.refresh_token);
+      setMessage('Logged in successfully. Tokens stored in localStorage.');
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unable to login';
+      setMessage(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="form">
+      <label>
+        Username
+        <input
+          type="text"
+          value={username}
+          onChange={(event) => setUsername(event.target.value)}
+          required
+        />
+      </label>
+      <label>
+        Password
+        <input
+          type="password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          minLength={8}
+          required
+        />
+      </label>
+      <button type="submit" disabled={isLoading}>
+        {isLoading ? 'Signing in...' : 'Sign in'}
+      </button>
+      {message ? <p>{message}</p> : null}
+    </form>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,52 @@
+import { Blog, PaginatedResponse, TokenResponse } from './types';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8000';
+
+export async function fetchBlogs(params?: {
+  search?: string;
+  limit?: number;
+  offset?: number;
+}): Promise<PaginatedResponse<Blog>> {
+  const query = new URLSearchParams();
+
+  if (params?.search) query.set('search', params.search);
+  if (params?.limit) query.set('limit', String(params.limit));
+  if (params?.offset) query.set('offset', String(params.offset));
+
+  const response = await fetch(`${API_BASE}/api/blogs?${query.toString()}`, {
+    next: { revalidate: 60 }
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch blogs');
+  }
+
+  return response.json();
+}
+
+export async function fetchBlogById(id: string): Promise<Blog> {
+  const response = await fetch(`${API_BASE}/api/blogs/${id}`, { cache: 'no-store' });
+
+  if (!response.ok) {
+    throw new Error('Blog not found');
+  }
+
+  return response.json();
+}
+
+export async function login(username: string, password: string): Promise<TokenResponse> {
+  const response = await fetch(`${API_BASE}/api/auth/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ username, password })
+  });
+
+  if (!response.ok) {
+    const data = await response.json();
+    throw new Error(data.detail ?? 'Login failed');
+  }
+
+  return response.json();
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,0 +1,32 @@
+export interface Author {
+  id: number;
+  username: string;
+  email?: string;
+  profile_picture_url?: string | null;
+}
+
+export interface Blog {
+  id: number;
+  title: string;
+  content?: string;
+  created_at: string;
+  updated_at?: string;
+  thumbnail_url?: string | null;
+  tags?: string[];
+  likes_count?: number;
+  comments_count?: number;
+  author?: Author;
+}
+
+export interface PaginatedResponse<T> {
+  total: number;
+  limit: number;
+  offset: number;
+  data: T[];
+}
+
+export interface TokenResponse {
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal Next.js frontend so the API can be quickly exercised in-browser and used for demos.
- Ship a TypeScript + App Router scaffold with basic UI so frontend integration work starts from a sensible baseline.
- Add docs and `.gitignore` entries to document how to run the frontend and avoid committing build artifacts and local env files.

### Description
- Added a new `frontend/` Next.js app with `package.json`, `tsconfig.json`, `next.config.mjs`, and ESLint config, plus `frontend/README.md` documenting `NEXT_PUBLIC_API_BASE_URL`.
- Implemented pages: homepage `src/app/page.tsx`, blog detail `src/app/blogs/[id]/page.tsx`, and login page `src/app/login/page.tsx`, plus app layout `src/app/layout.tsx` and global styles `src/app/globals.css`.
- Added reusable components `src/components/blog-card.tsx` and `src/components/login-form.tsx`, and client API utilities `src/lib/api.ts` with TypeScript models in `src/lib/types.ts` to call `GET /api/blogs`, `GET /api/blogs/{id}`, and `POST /api/auth/login`.
- Updated project docs (`README.md`) with instructions to run the frontend and updated `.gitignore` to exclude `frontend/node_modules`, `.next`, and `frontend/.env.local`.

### Testing
- Ran `npm install` in `frontend/`, which failed with `403 Forbidden` from the npm registry due to registry access restrictions in this environment (installation did not complete).
- Ran an automated Playwright script attempting to load `http://127.0.0.1:3000`, which failed with `ERR_EMPTY_RESPONSE` because the dev server was not running after the dependency install failure.
- No frontend unit or integration tests were added in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69847e39aee0832ebbb2e7dc0d1ddcdc)

## Summary by Sourcery

Add a minimal Next.js frontend application to interact with the SaaS Blog API and document how to run it alongside the backend.

New Features:
- Introduce a Next.js 14 TypeScript app under frontend/ with basic configuration, build scripts, and strict TS/ESLint setup.
- Add blog listing, blog detail, and login pages wired to the SaaS Blog API using shared typed client utilities.
- Provide reusable UI components for blog cards and a login form that stores received auth tokens in localStorage.

Documentation:
- Document how to run the new Next.js frontend and configure NEXT_PUBLIC_API_BASE_URL in both the root README and frontend-specific README.